### PR TITLE
KUBOS-132 Added KUARTStatus return codes

### DIFF
--- a/source/uart.c
+++ b/source/uart.c
@@ -175,16 +175,16 @@ static inline uint8_t uart_alt(KUARTNum uart)
 /**
  * Setup and enable uart bus
  * @param uart uart bus to initialize
- * @return int 0 if success, otherwise a non-zero error number
+ * @return KUARTStatus UART_OK if success, otherwise failure
  */
-int kprv_uart_dev_init(KUARTNum uart)
+KUARTStatus kprv_uart_dev_init(KUARTNum uart)
 {
 	HAL_StatusTypeDef ret = 0;
 
     // Enable peripheral clocks
     KUART *k_uart = kprv_uart_get(uart);
-    if (!k_uart) {
-        return -1;
+    if (k_uart == NULL) {
+        return UART_ERROR_NULL_HANDLE;
     }
 
     int rx = k_uart_rx_pin(uart);
@@ -323,19 +323,19 @@ void kprv_uart_enable_tx_int(KUARTNum uart)
  * Write a character directly to the uart interface
  * @param uart uart bus
  * @param c character to write
- * @return int 0 if success, otherwise a non-zero error number
+ * @return KUARTStatus UART_OK if success, otherwise failure
  */
-int k_uart_write_immediate(KUARTNum uart, char c)
+KUARTStatus k_uart_write_immediate(KUARTNum uart, char c)
 {
     USART_TypeDef *dev = uart_dev(uart);
-    if (!dev) {
-        return -1;
+    if (dev ==  NULL) {
+        return UART_ERROR_NULL_HANDLE;
     }
 
     dev->DR = c;
     while (!CHECK_BIT(dev->SR, UART_FLAG_TXE));
 
-    return 0;
+    return UART_OK;
 }
 
 #define __GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->SR & (__FLAG__)) == (__FLAG__))

--- a/test/i2c.c
+++ b/test/i2c.c
@@ -1,6 +1,6 @@
 /*
  * KubOS Core Flight Services
- * Copyright (C) 2015 Kubos Corporation
+ * Copyright (C) 2016 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@
 #define NUM_BNO055_OFFSET_REGISTERS (22)
 
 //Establishes configuration and initialization for the tests
-void test_setup(void)
+void test_i2c_setup(void)
 {
 	int ret;
 
@@ -72,6 +72,17 @@ void test_setup(void)
 static void test_i2c_initGood(void)
 {
     int ret;
+
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_MASTER,
+        .clock_speed = 100000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
 
     ret = kprv_i2c_dev_init(I2C_BUS);
     kprv_i2c_dev_terminate(I2C_BUS);
@@ -107,6 +118,17 @@ static void test_i2c_initBad(void)
 static void test_i2c_termInit(void)
 {
     int ret;
+
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_MASTER,
+        .clock_speed = 100000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
 
     ret = kprv_i2c_dev_init(I2C_BUS);
     TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
@@ -160,7 +182,7 @@ static void test_i2c_writeMasterGood(void)
     int ret;
     uint8_t buffer[2] = {(uint8_t)61, 0x00}; //cmd (0x3D): Set bno055 sensor to config mode (0x00)
 
-	test_setup();
+	test_i2c_setup();
 
     //Send request for data
     ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)buffer, 2);
@@ -201,7 +223,7 @@ static void test_i2c_writeMasterOverflow(void)
     int ret;
     uint8_t buffer[2] = {(uint8_t)61, 0x00}; //cmd (0x3D): Set bno055 sensor to config mode (0x00)
 
-	test_setup();
+	test_i2c_setup();
 
     //Send request for data
     ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)buffer, 200);
@@ -225,7 +247,7 @@ static void test_i2c_readMasterGood(void)
 	uint8_t id;
 	uint8_t reg = BNO055_CHIP_ID_ADDR;
 
-	test_setup();
+	test_i2c_setup();
 
     //Send request for data
     ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)&reg, 1);
@@ -252,7 +274,7 @@ static void test_i2c_readMasterBad(void)
     int ret;
     uint8_t value = 0;
 
-    test_setup();
+    test_i2c_setup();
 
 	ret = kprv_i2c_master_read(I2C_BUS, 0x80, &value, 1);
 
@@ -274,7 +296,7 @@ static void test_i2c_readMasterNoWrite(void)
     int ret;
     uint8_t value = 0;
 
-    test_setup();
+    test_i2c_setup();
 
 	ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, &value, 1);
 
@@ -295,7 +317,7 @@ static void test_i2c_readMasterOverflow(void)
 	char buffer[100] = {0};
 	uint8_t reg = BNO055_CHIP_ID_ADDR;
 
-	test_setup();
+	test_i2c_setup();
 
     //Send request for data
     ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)&reg, 1);

--- a/test/spi.c
+++ b/test/spi.c
@@ -1,6 +1,6 @@
 /*
  * KubOS Core Flight Services
- * Copyright (C) 2015 Kubos Corporation
+ * Copyright (C) 2016 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@
 #define CS PA4
 #define SPI_BUS K_SPI1
 
-void test_setup(void)
+void test_spi_setup(void)
 {
 	int ret = 0;
     uint8_t resetReg = 0xE0 & ~0x80; //Reset register, high bit low for write request
@@ -132,7 +132,7 @@ static void test_spi_termInit(void)
 {
 	int ret;
 
-	test_setup();
+	test_spi_setup();
 
 	ret = kprv_spi_dev_terminate(SPI_BUS);
 	TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to terminate SPI_BUS");
@@ -183,7 +183,7 @@ static void test_spi_writeMaster(void)
 	uint8_t chipReg = 0xD0; //Chip ID register
 	chipReg |= 0x80; //Turn on high bit for read request
 
-	test_setup();
+	test_spi_setup();
 
 	k_gpio_write(CS, 0);
 
@@ -212,7 +212,7 @@ static void test_spi_writeMasterNoCS(void)
 	uint8_t chipReg = 0xD0;
 	chipReg |= 0x80;
 
-	test_setup();
+	test_spi_setup();
 
 	ret = kprv_spi_write(SPI_BUS, &chipReg, 1);
 
@@ -263,7 +263,7 @@ static void test_spi_writeMasterOverflow(void)
 	uint8_t chipReg = 0xD0; //Chip ID register
 	chipReg |= 0x80; //Turn on high bit for read request
 
-	test_setup();
+	test_spi_setup();
 
 	k_gpio_write(CS, 0);
 
@@ -293,7 +293,7 @@ static void test_spi_readMaster(void)
 	uint8_t chipReg = 0xD0;
 	chipReg |= 0x80;
 
-	test_setup();
+	test_spi_setup();
 
 	k_gpio_write(CS, 0);
 
@@ -328,7 +328,7 @@ static void test_spi_readMasterNoCS(void)
 	uint8_t chipReg = 0xD0;
 	chipReg |= 0x80;
 
-	test_setup();
+	test_spi_setup();
 
 	ret = kprv_spi_write(SPI_BUS, &chipReg, 1);
 	TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
@@ -357,7 +357,7 @@ static void test_spi_readMasterNoWrite(void)
 	int ret;
 	uint8_t id = 0;
 
-	test_setup();
+	test_spi_setup();
 
 	k_gpio_write(CS, 0);
 
@@ -387,7 +387,7 @@ static void test_spi_writeReadMaster(void)
 	uint8_t id = 0;
 	uint8_t buffer[1] = {0xD0};
 
-	test_setup();
+	test_spi_setup();
 
 	k_gpio_write(CS, 0);
 
@@ -414,7 +414,7 @@ static void test_spi_readMasterOverflow(void)
 	uint8_t chipReg = 0xD0;
 	chipReg |= 0x80;
 
-	test_setup();
+	test_spi_setup();
 
 	k_gpio_write(CS, 0);
 

--- a/test/uart.c
+++ b/test/uart.c
@@ -92,7 +92,7 @@ static void test_uart_write(void)
     k_uart_init(uartTo, &conf);
     returnLen = k_uart_write(uartTo, testString, len);
 
-    kprv_uart_dev_terminate(uartTo);
+    k_uart_terminate(uartTo);
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLen, "Failed to write");
 }
 
@@ -119,8 +119,8 @@ static void test_uart_writeOverflow(void)
 
     //Clean up the receive buffer
     while(k_uart_read(uartFrom, buffer, 100) != 0);
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
 
     TEST_ASSERT_EQUAL_INT_MESSAGE(50, returnLen, "Failed to write");
 
@@ -154,8 +154,8 @@ static void test_uart_read(void)
 
     returnLenRead = k_uart_read(uartTo, testString, len);
 
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenRead, "Failed to read");
 }
@@ -191,8 +191,8 @@ static void test_uart_readOverflow(void)
 
     returnLenRead = k_uart_read(uartTo, buffer, 100);
 
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenRead, "Failed to read");
 }
@@ -224,8 +224,8 @@ static void test_uart_writeImmediate(void)
 
     returnLen = k_uart_read(uartFrom, recvString, len);
 
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
     TEST_ASSERT_EQUAL_MEMORY("a", recvString, 1);
     TEST_ASSERT_EQUAL_INT(1, returnLen);
 }
@@ -262,8 +262,8 @@ static void test_uart_wordLen(void)
 
     returnLenRead = k_uart_read(uartTo, testString, len);
 
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
 }
@@ -300,8 +300,8 @@ static void test_uart_parity(void)
 
     returnLenRead = k_uart_read(uartTo, testString, len);
 
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
 }
@@ -338,8 +338,8 @@ static void test_uart_baudRate(void)
 
     returnLenRead = k_uart_read(uartTo, testString, len);
 
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
 }
@@ -383,8 +383,8 @@ static void test_uart_overrun(void)
 
     returnLenRead = k_uart_read(uartTo, testString, len);
 
-    kprv_uart_dev_terminate(uartTo);
-    kprv_uart_dev_terminate(uartFrom);
+    k_uart_terminate(uartTo);
+    k_uart_terminate(uartFrom);
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
 }

--- a/test/uart.c
+++ b/test/uart.c
@@ -52,7 +52,7 @@ static void test_uart_initGood(void)
     ret = kprv_uart_dev_init(uartTo);
 
     kprv_uart_dev_terminate(uartTo);
-    TEST_ASSERT_EQUAL_INT_MESSAGE(0, ret, "Failed to init UART1");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(UART_OK, ret, "Failed to init UART1");
 }
 
 /*
@@ -70,7 +70,7 @@ static void test_uart_initBad(void)
 
     ret = kprv_uart_dev_init(num);
 
-    TEST_ASSERT_EQUAL_INT(-1, ret);
+    TEST_ASSERT_EQUAL_INT(UART_ERROR_NULL_HANDLE, ret);
 }
 
 /*

--- a/test/uart.c
+++ b/test/uart.c
@@ -1,6 +1,6 @@
 /*
  * KubOS Core Flight Services
- * Copyright (C) 2015 Kubos Corporation
+ * Copyright (C) 2016 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,6 @@ static void test_uart_writeOverflow(void)
 static void test_uart_read(void)
 {
     KUARTConf conf;
-    KUART *k_uart;
     char * testString = "test string 1";
     int len = strlen(testString);
     int returnLenWrite = 0;

--- a/test/uart.c
+++ b/test/uart.c
@@ -345,7 +345,7 @@ static void test_uart_baudRate(void)
 }
 
 /*
- * test_uart_wordLen
+ * test_uart_overrun
  *
  * Purpose:  Test UART receive processing when a character is received before the previous character has
  * 	been processed.


### PR DESCRIPTION
Converted int return codes to more readable KUARTStatus values:
    UART_OK,
    UART_ERROR,
    UART_ERROR_NULL_HANDLE,
    UART_ERROR_CONFIG